### PR TITLE
Added MyXQL adapter to config template

### DIFF
--- a/lib/mix/giza.sphinx.config.ex
+++ b/lib/mix/giza.sphinx.config.ex
@@ -181,6 +181,10 @@ defmodule Mix.Tasks.Giza.Sphinx.Config do
     get_db_conf_map(db_conf, Map.put(acc, :type, "mysql"))
   end
 
+  defp get_db_conf_map([{:adapter, Ecto.Adapters.MyXQL}|db_conf], %{} = acc) do
+    get_db_conf_map(db_conf, Map.put(acc, :type, "mysql"))
+  end
+
   defp get_db_conf_map([_|db_conf], %{} = acc) do
     get_db_conf_map(db_conf, acc)
   end


### PR DESCRIPTION
Currently, the configuration doesn't detect the "mysql" type when the MyXQL Ecto adapter is used, leading to the following error:

```
** (FunctionClauseError) no function clause matching in Mix.Tasks.Giza.Sphinx.Config.generate_source/1

    The following arguments were given to Mix.Tasks.Giza.Sphinx.Config.generate_source/1:

        # 1
        %{database: "db", hostname: "127.0.0.1", password: "", username: "root"}

    Attempted function clauses (showing 1 out of 1):

        defp generate_source(%{type: type, database: database, username: username, password: password, hostname: hostname})

    lib/mix/giza.sphinx.config.ex:42: Mix.Tasks.Giza.Sphinx.Config.generate_source/1
    lib/mix/giza.sphinx.config.ex:20: Mix.Tasks.Giza.Sphinx.Config.run/1
    (mix 1.10.3) lib/mix/task.ex:330: Mix.Task.run_task/3
    (mix 1.10.3) lib/mix/cli.ex:82: Mix.CLI.run_task/2
```

This patch adds a line to the matching portion of the Mix task to detect the type when the MyXQL adapter is used.