### PR TITLE
Fix errors with ':unicode.characters_to_binary' in Mariaex

### DIFF
--- a/lib/giza/application.ex
+++ b/lib/giza/application.ex
@@ -14,7 +14,7 @@ defmodule Giza.Application do
 		  name: :mysql_sphinx_client, 
 		  hostname: Application.get_env(:giza_sphinxsearch, :host, "localhost"), 
 		  port: Application.get_env(:giza_sphinxsearch, :sql_port, 9306), 
-      username: "",
+		  username: "",
 		  skip_database: true,
 		  sock_type: :tcp
 		}


### PR DESCRIPTION
Startup fails with the following.  Appears to be related to https://github.com/xerions/mariaex/issues/246

```
** (RuntimeError) connect raised ArgumentError exception. The exception details are hidden, as they may contain sensitive data such as database credentials. You may set :show_sensitive_data_on_connection_error to true when starting your connection if you wish to see all of the details
(stdlib 3.12.1) :unicode.characters_to_binary/1
(mariaex 0.9.1) lib/mariaex/protocol.ex:215: Mariaex.Protocol.handle_handshake/3
(mariaex 0.9.1) lib/mariaex/protocol.ex:171: Mariaex.Protocol.handshake_recv/2
(db_connection 2.2.2) lib/db_connection/connection.ex:69: DBConnection.Connection.connect/2
(connection 1.0.4) lib/connection.ex:622: Connection.enter_connect/5
(stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```